### PR TITLE
[#187082048] Add Django 4 compatibility

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,12 @@
+0.22.rc2 - 2024/06/20
+
+* Fix compatibility with Django 4.0
+* Cut some Python2-specific code
+* Cut languages not required for the project
+* Add management script for Demo project
+
 0.22.rc1 - 2022/12/02
+-------------------
 
 * Fix backwards incompatible shortened URLs to include trailing slash
 * Fix unicode compatibility for author names

--- a/demo/manage.py
+++ b/demo/manage.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+import os
+import sys
+
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'demo.settings')
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/demo/settings.py
+++ b/demo/settings.py
@@ -28,31 +28,6 @@ LANGUAGE_CODE = 'en'
 
 LANGUAGES = (
     ('en', gettext('English')),
-    ('fr', gettext('French')),
-    ('de', gettext('German')),
-    ('es', gettext('Spanish')),
-    ('it', gettext('Italian')),
-    ('nl', gettext('Dutch')),
-    ('sl', gettext('Slovenian')),
-    ('bg', gettext('Bulgarian')),
-    ('hu', gettext('Hungarian')),
-    ('cs', gettext('Czech')),
-    ('sk', gettext('Slovak')),
-    ('lt', gettext('Lithuanian')),
-    ('ru', gettext('Russian')),
-    ('pl', gettext('Polish')),
-    ('eu', gettext('Basque')),
-    ('he', gettext('Hebrew')),
-    ('ca', gettext('Catalan')),
-    ('tr', gettext('Turkish')),
-    ('sv', gettext('Swedish')),
-    ('is', gettext('Icelandic')),
-    ('hr_HR', gettext('Croatian')),
-    ('pt_BR', gettext('Brazilian Portuguese')),
-    ('fa_IR', gettext('Persian')),
-    ('fi_FI', gettext('Finnish')),
-    ('uk_UA', gettext('Ukrainian')),
-    ('zh-hans', gettext('Simplified Chinese')),
 )
 
 MIDDLEWARE = [

--- a/demo/urls.py
+++ b/demo/urls.py
@@ -3,7 +3,7 @@ from functools import partial
 
 from django.conf import settings
 from django.conf.urls import include
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib import admin
 from django.contrib.sitemaps.views import index
 from django.contrib.sitemaps.views import sitemap
@@ -23,13 +23,13 @@ from zinnia.sitemaps import TagSitemap
 
 
 urlpatterns = [
-    url(r'^$', RedirectView.as_view(url='/blog/', permanent=True)),
-    url(r'^blog/', include('zinnia.urls')),
-    url(r'^comments/', include('django_comments.urls')),
-    url(r'^xmlrpc/$', handle_xmlrpc),
-    url(r'^i18n/', include('django.conf.urls.i18n')),
-    url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^$', RedirectView.as_view(url='/blog/', permanent=True)),
+    re_path(r'^blog/', include('zinnia.urls')),
+    re_path(r'^comments/', include('django_comments.urls')),
+    re_path(r'^xmlrpc/$', handle_xmlrpc),
+    re_path(r'^i18n/', include('django.conf.urls.i18n')),
+    re_path(r'^admin/doc/', include('django.contrib.admindocs.urls')),
+    re_path(r'^admin/', admin.site.urls),
 ]
 
 sitemaps = {
@@ -40,23 +40,23 @@ sitemaps = {
 }
 
 urlpatterns += [
-    url(r'^sitemap.xml$',
+    re_path(r'^sitemap.xml$',
         index,
         {'sitemaps': sitemaps}),
-    url(r'^sitemap-(?P<section>.+)\.xml$',
+    re_path(r'^sitemap-(?P<section>.+)\.xml$',
         sitemap,
         {'sitemaps': sitemaps}),
 ]
 
 urlpatterns += [
-    url(r'^400/$', partial(bad_request, exception=None)),
-    url(r'^403/$', partial(permission_denied, exception=None)),
-    url(r'^404/$', partial(page_not_found, exception=None)),
-    url(r'^500/$', server_error),
+    re_path(r'^400/$', partial(bad_request, exception=None)),
+    re_path(r'^403/$', partial(permission_denied, exception=None)),
+    re_path(r'^404/$', partial(page_not_found, exception=None)),
+    re_path(r'^500/$', server_error),
 ]
 
 if settings.DEBUG:
     urlpatterns += [
-        url(r'^media/(?P<path>.*)$', serve,
+        re_path(r'^media/(?P<path>.*)$', serve,
             {'document_root': settings.MEDIA_ROOT})
     ]

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
                       'beautifulsoup4>=4.3.2',
                       'django-contrib-comments>=1.7.2',
                       'django-mptt>=0.8.6',
-                      'django-tagging>=0.4.5',
                       'django-xmlrpc>=0.1.5',
                       'mots-vides>=2015.5.11',
                       'pillow>=2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license=zinnia.__license__,
     include_package_data=True,
     zip_safe=False,
-    install_requires=['Django>=2.2,<4',
+    install_requires=['Django>=4',
                       'beautifulsoup4>=4.3.2',
                       'django-contrib-comments>=1.7.2',
                       'django-mptt>=0.8.6',

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     license=zinnia.__license__,
     include_package_data=True,
     zip_safe=False,
-    install_requires=['Django>=4',
+    install_requires=['Django>=3.2,<5',
                       'beautifulsoup4>=4.3.2',
                       'django-contrib-comments>=1.7.2',
                       'django-mptt>=0.8.6',

--- a/zinnia/__init__.py
+++ b/zinnia/__init__.py
@@ -1,5 +1,5 @@
 """Zinnia"""
-__version__ = '0.22.rc1'
+__version__ = '0.22.rc2'
 __license__ = 'BSD License'
 
 __author__ = 'Fantomas42'

--- a/zinnia/admin/entry.py
+++ b/zinnia/admin/entry.py
@@ -1,6 +1,4 @@
 """EntryAdmin for Zinnia"""
-from __future__ import unicode_literals
-
 from django.contrib import admin
 from django.contrib.sites.models import Site
 from django.db.models import Q

--- a/zinnia/breadcrumbs.py
+++ b/zinnia/breadcrumbs.py
@@ -10,7 +10,7 @@ from django.utils.timezone import localtime
 from django.utils.translation import gettext as _
 
 
-class Crumb(object):
+class Crumb:
     """
     Part of the breadcrumbs.
     """

--- a/zinnia/calendar.py
+++ b/zinnia/calendar.py
@@ -1,6 +1,4 @@
 """Calendar module for Zinnia"""
-from __future__ import absolute_import
-
 from calendar import HTMLCalendar
 from datetime import date
 

--- a/zinnia/comparison.py
+++ b/zinnia/comparison.py
@@ -36,7 +36,7 @@ def pearson_score(list1, list2):
     return num / den
 
 
-class ModelVectorBuilder(object):
+class ModelVectorBuilder:
     """
     Build a list of vectors based on a Queryset.
     """

--- a/zinnia/ping.py
+++ b/zinnia/ping.py
@@ -16,7 +16,7 @@ from zinnia.flags import PINGBACK
 from zinnia.settings import PROTOCOL
 
 
-class URLRessources(object):
+class URLRessources:
     """
     Object defining the ressources of the Website.
     """

--- a/zinnia/preview.py
+++ b/zinnia/preview.py
@@ -1,6 +1,4 @@
 """Preview for Zinnia"""
-from __future__ import division
-
 from bs4 import BeautifulSoup
 
 from django.utils.functional import cached_property
@@ -12,7 +10,7 @@ from zinnia.settings import PREVIEW_MORE_STRING
 from zinnia.settings import PREVIEW_SPLITTERS
 
 
-class HTMLPreview(object):
+class HTMLPreview:
     """
     Build an HTML preview of an HTML content.
     """

--- a/zinnia/templates/comments/zinnia/entry/form.html
+++ b/zinnia/templates/comments/zinnia/entry/form.html
@@ -12,7 +12,7 @@
     {% for field in form %}
     {% if field.is_hidden %}{{ field }}{% else %}
     {% if user.email and field.name in "namemailurl" %}{% else %}
-    <div{% if field.errors %} class="error"{% endif %}{% ifequal field.name "honeypot" %} style="display:none;"{% endifequal %}>
+    <div{% if field.errors %} class="error"{% endif %}{% if field.name == "honeypot" %} style="display:none;"{% endif %}>
       {{ field.label_tag }}
       {% if field.errors %}{{ field.errors }}{% endif %}
       {{ field }}

--- a/zinnia/templates/zinnia/entry_list.html
+++ b/zinnia/templates/zinnia/entry_list.html
@@ -21,7 +21,7 @@
 
 {% endspaceless %}{% endblock meta-description %}
 
-{% block meta-description-page %}{% if page_obj %}{% ifnotequal page_obj.number 1 %} {% blocktrans with page_number=page_obj.number %}page {{ page_number }}{% endblocktrans %}{% endifnotequal %}{% endif %}{% endblock meta-description-page %}
+{% block meta-description-page %}{% if page_obj %}{% if page_obj.number != 1 %} {% blocktrans with page_number=page_obj.number %}page {{ page_number }}{% endblocktrans %}{% endif %}{% endif %}{% endblock meta-description-page %}
 
 {% block title %}{% spaceless %}
 {% if category %}
@@ -38,7 +38,7 @@
 
 {% endspaceless %}{% endblock title %}
 
-{% block title-page %}{% if page_obj %}{% ifnotequal page_obj.number 1 %} - {% blocktrans with object=page_obj.number %}Page {{ object }}{% endblocktrans %}{% endifnotequal %}{% endif %}{% endblock title-page %}
+{% block title-page %}{% if page_obj %}{% if page_obj.number != 1 %} - {% blocktrans with object=page_obj.number %}Page {{ object }}{% endblocktrans %}{% endif %}{% endif %}{% endblock title-page %}
 
 {% block link %}
   {{ block.super }}

--- a/zinnia/templates/zinnia/tags/pagination.html
+++ b/zinnia/templates/zinnia/tags/pagination.html
@@ -13,26 +13,26 @@
     {% endif %}
 
     {% for page_number in begin %}
-    <li class="page{% ifequal page.number page_number %} current{% endifequal %}">
-      {% ifequal page.number page_number %}
+    <li class="page{% if page.number == page_number %} current{% endif %}">
+      {% if page.number == page_number %}
       {{ page_number }}
       {% else %}
       <a href="?page={{ page_number }}{{ GET_string }}"
          title="{% trans "Entries page" %} {{ page_number }}">{{ page_number }}</a>
-      {% endifequal%}
+      {% endif%}
     </li>
     {% endfor %}
 
     {% if middle %}
     <li class="ellipsis">&hellip;</li>
     {% for page_number in middle %}
-    <li class="page{% ifequal page.number page_number %} current{% endifequal %}">
-      {% ifequal page.number page_number %}
+    <li class="page{% if page.number == page_number %} current{% endif %}">
+      {% if page.number == page_number %}
       {{ page_number }}
       {% else %}
       <a href="?page={{ page_number }}{{ GET_string }}"
          title="{% trans "Entries page" %} {{ page_number }}">{{ page_number }}</a>
-      {% endifequal%}
+      {% endif%}
     </li>
     {% endfor %}
     {% endif %}
@@ -40,13 +40,13 @@
     {% if end %}
     <li class="ellipsis">&hellip;</li>
     {% for page_number in end %}
-    <li class="page{% ifequal page.number page_number %} current{% endifequal %}">
-      {% ifequal page.number page_number %}
+    <li class="page{% if page.number == page_number %} current{% endif %}">
+      {% if page.number == page_number %}
       {{ page_number }}
       {% else %}
       <a href="?page={{ page_number }}{{ GET_string }}"
          title="{% trans "Entries page" %} {{ page_number }}">{{ page_number }}</a>
-      {% endifequal%}
+      {% endif%}
     </li>
     {% endfor %}
     {% endif %}

--- a/zinnia/tests/implementations/urls/custom_detail_views.py
+++ b/zinnia/tests/implementations/urls/custom_detail_views.py
@@ -1,5 +1,4 @@
 """Test urls for the zinnia project"""
-from django.conf.urls import url
 from django.urls import path
 
 from zinnia.tests.implementations.urls.default import (

--- a/zinnia/tests/implementations/urls/custom_detail_views.py
+++ b/zinnia/tests/implementations/urls/custom_detail_views.py
@@ -9,7 +9,7 @@ from zinnia.views.categories import CategoryDetail
 from zinnia.views.tags import TagDetail
 
 
-class CustomModelDetailMixin(object):
+class CustomModelDetailMixin:
     """
     Mixin for changing the template_name
     and overriding the context.

--- a/zinnia/tests/implementations/urls/default.py
+++ b/zinnia/tests/implementations/urls/default.py
@@ -1,6 +1,5 @@
 """Test urls for the zinnia project"""
 from django.conf.urls import include
-from django.conf.urls import url
 from django.contrib import admin
 from django.urls import path
 

--- a/zinnia/tests/implementations/urls/poor.py
+++ b/zinnia/tests/implementations/urls/poor.py
@@ -1,6 +1,5 @@
 """Poor test urls for the zinnia project"""
 from django.conf.urls import include
-from django.conf.urls import url
 from django.contrib import admin
 from django.urls import path
 

--- a/zinnia/tests/test_admin.py
+++ b/zinnia/tests/test_admin.py
@@ -1,7 +1,4 @@
-# coding=utf-8
 """Test cases for Zinnia's admin"""
-from __future__ import unicode_literals
-
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
@@ -54,7 +51,7 @@ class BaseAdminTestCase(TestCase):
             self.assertEqual(func(*args), result_poor)
 
 
-class TestMessageBackend(object):
+class TestMessageBackend:
     """Message backend for testing"""
     def __init__(self, *ka, **kw):
         self.messages = []
@@ -397,7 +394,7 @@ class EntryAdminTestCase(BaseAdminTestCase):
         self.assertEqual(len(self.request._messages.messages), 2)
 
     def test_ping_directories(self):
-        class FakePinger(object):
+        class FakePinger:
             def __init__(self, *ka, **kw):
                 self.results = [{'flerror': False, 'message': 'OK'},
                                 {'flerror': True, 'message': 'KO'}]

--- a/zinnia/tests/test_admin_fields.py
+++ b/zinnia/tests/test_admin_fields.py
@@ -16,7 +16,7 @@ class MPTTModelChoiceIteratorTestCase(TestCase):
             title='Category 2', slug='cat-2',
             parent=category_1)
 
-        class FakeField(object):
+        class FakeField:
             queryset = Category.objects.all()
 
             def prepare_value(self, value):

--- a/zinnia/tests/test_mixins.py
+++ b/zinnia/tests/test_mixins.py
@@ -145,7 +145,7 @@ class MixinTestCase(TestCase):
              'entry_archive.html'])
 
     def test_entry_archive_template_response_mixin(self):
-        class FakeEntry(object):
+        class FakeEntry:
             detail_template = 'entry_detail.html'
             slug = 'my-fake-entry'
 
@@ -348,7 +348,7 @@ class MixinTestCase(TestCase):
             entry.authors.add(author)
             entry.categories.add(category)
 
-        class View(object):
+        class View:
             def get_queryset(self):
                 return Entry.objects.all()
 

--- a/zinnia/tests/test_ping.py
+++ b/zinnia/tests/test_ping.py
@@ -12,7 +12,7 @@ from zinnia.ping import URLRessources
 from zinnia.signals import disconnect_entry_signals
 
 
-class FakeThread(object):
+class FakeThread:
     def start(self):
         pass
 

--- a/zinnia/tests/test_templatetags.py
+++ b/zinnia/tests/test_templatetags.py
@@ -616,7 +616,7 @@ class TemplateTagsTestCase(TestCase):
                              self.entry)
 
     def test_zinnia_pagination(self):
-        class FakeRequest(object):
+        class FakeRequest:
             def __init__(self, get_dict):
                 self.GET = get_dict
 
@@ -758,7 +758,7 @@ class TemplateTagsTestCase(TestCase):
         Reproduce the issue encountred on my website,
         versus the expected result.
         """
-        class FakeRequest(object):
+        class FakeRequest:
             def __init__(self, get_dict={}):
                 self.GET = get_dict
 
@@ -778,11 +778,11 @@ class TemplateTagsTestCase(TestCase):
 
     @skip_if_custom_user
     def test_zinnia_breadcrumbs(self):
-        class FakeRequest(object):
+        class FakeRequest:
             def __init__(self, path):
                 self.path = path
 
-        class FakePage(object):
+        class FakePage:
             def __init__(self, number):
                 self.number = number
 

--- a/zinnia/tests/test_url_shortener.py
+++ b/zinnia/tests/test_url_shortener.py
@@ -41,7 +41,7 @@ class URLShortenerTestCase(TestCase):
         self.assertEqual(get_url_shortener(), default.backend)
 
 
-class FakeEntry(object):
+class FakeEntry:
     """Fake entry with only 'pk' as attribute"""
     def __init__(self, pk):
         self.pk = pk

--- a/zinnia/views/authors.py
+++ b/zinnia/views/authors.py
@@ -24,7 +24,7 @@ class AuthorList(ListView):
             count_entries_published=Count('entries'))
 
 
-class BaseAuthorDetail(object):
+class BaseAuthorDetail:
     """
     Mixin providing the behavior of the author detail view,
     by returning in the context the current author and a

--- a/zinnia/views/categories.py
+++ b/zinnia/views/categories.py
@@ -32,7 +32,7 @@ class CategoryList(ListView):
             count_entries_published=Count('entries'))
 
 
-class BaseCategoryDetail(object):
+class BaseCategoryDetail:
     """
     Mixin providing the behavior of the category detail view,
     by returning in the context the current category and a

--- a/zinnia/views/channels.py
+++ b/zinnia/views/channels.py
@@ -6,7 +6,7 @@ from zinnia.settings import PAGINATION
 from zinnia.views.mixins.prefetch_related import PrefetchCategoriesAuthorsMixin
 
 
-class BaseEntryChannel(object):
+class BaseEntryChannel:
     """
     Mixin for displaying a custom selection of entries
     based on a search query, useful to build SEO/SMO pages

--- a/zinnia/views/mixins/archives.py
+++ b/zinnia/views/mixins/archives.py
@@ -7,7 +7,7 @@ from zinnia.settings import ALLOW_FUTURE
 from zinnia.settings import PAGINATION
 
 
-class ArchiveMixin(object):
+class ArchiveMixin:
     """
     Mixin centralizing the configuration of the archives views.
     """
@@ -19,7 +19,7 @@ class ArchiveMixin(object):
     week_format = '%W'
 
 
-class PreviousNextPublishedMixin(object):
+class PreviousNextPublishedMixin:
     """
     Mixin for correcting the previous/next
     context variable to return dates with published datas.

--- a/zinnia/views/mixins/callable_queryset.py
+++ b/zinnia/views/mixins/callable_queryset.py
@@ -2,7 +2,7 @@
 from django.core.exceptions import ImproperlyConfigured
 
 
-class CallableQuerysetMixin(object):
+class CallableQuerysetMixin:
     """
     Mixin for handling a callable queryset,
     which will force the update of the queryset.

--- a/zinnia/views/mixins/entry_cache.py
+++ b/zinnia/views/mixins/entry_cache.py
@@ -1,7 +1,7 @@
 """Cache mixins for Zinnia views"""
 
 
-class EntryCacheMixin(object):
+class EntryCacheMixin:
     """
     Mixin implementing cache on ``get_object`` method.
     """

--- a/zinnia/views/mixins/entry_preview.py
+++ b/zinnia/views/mixins/entry_preview.py
@@ -3,7 +3,7 @@ from django.http import Http404
 from django.utils.translation import gettext as _
 
 
-class EntryPreviewMixin(object):
+class EntryPreviewMixin:
     """
     Mixin implementing the preview of Entries.
     """

--- a/zinnia/views/mixins/entry_protection.py
+++ b/zinnia/views/mixins/entry_protection.py
@@ -2,7 +2,7 @@
 from django.contrib.auth.views import LoginView
 
 
-class LoginMixin(object):
+class LoginMixin:
     """
     Mixin implemeting a login view
     configurated for Zinnia.
@@ -17,7 +17,7 @@ class LoginMixin(object):
         )(self.request)
 
 
-class PasswordMixin(object):
+class PasswordMixin:
     """
     Mixin implementing a password view
     configurated for Zinnia.

--- a/zinnia/views/mixins/prefetch_related.py
+++ b/zinnia/views/mixins/prefetch_related.py
@@ -2,7 +2,7 @@
 from django.core.exceptions import ImproperlyConfigured
 
 
-class PrefetchRelatedMixin(object):
+class PrefetchRelatedMixin:
     """
     Mixin allow you to provides list of relation names
     to be prefetching when the queryset is build.

--- a/zinnia/views/search.py
+++ b/zinnia/views/search.py
@@ -7,7 +7,7 @@ from zinnia.settings import PAGINATION
 from zinnia.views.mixins.prefetch_related import PrefetchCategoriesAuthorsMixin
 
 
-class BaseEntrySearch(object):
+class BaseEntrySearch:
     """
     Mixin providing the behavior of the entry search view,
     by returning in the context the pattern searched, the

--- a/zinnia/views/tags.py
+++ b/zinnia/views/tags.py
@@ -31,7 +31,7 @@ class TagList(ListView):
             Entry.published.all(), counts=True)
 
 
-class BaseTagDetail(object):
+class BaseTagDetail:
     """
     Mixin providing the behavior of the tag detail view,
     by returning in the context the current tag and a

--- a/zinnia/xmlrpc/pingback.py
+++ b/zinnia/xmlrpc/pingback.py
@@ -33,7 +33,7 @@ PINGBACK_ALREADY_REGISTERED = 48
 PINGBACK_IS_SPAM = 51
 
 
-class FakeRequest(object):
+class FakeRequest:
     META = {}
 
 


### PR DESCRIPTION
# Proposed changes

This PR adds Django 4 support to the Housekeep fork of [the original Zinnia project](https://github.com/Fantomas42/django-blog-zinnia), which has not been maintained for several years.

A summary of the changes made here is:

- Bump the Django version specified in the `setup.py` to be at least 4.0.0
- Cut the `django-tagging` dependency from `setup.py`: `django-tagging` is another unmaintained package which doesn't support Django 4. A [Housekeep-specific fork](https://github.com/HousekeepLtd/django-tagging) of this package has been created, which (i) supports Django 4 and (ii) fixes some other (maybe Django-4 related?) bugs.
- Fix some outdated imports in the demo project: this means it actually runs and can be used to test the project!
- Update some Python 2 specific code (object inheritance, `__future__` imports)

Note that the change to the `django-tagging` dependency means that from now on, we'll have to list that dependency in the main Housekeep repo's Pipfile.